### PR TITLE
updates for recent changes to lightning server, notebook support

### DIFF
--- a/LightningR/R/lightning.R
+++ b/LightningR/R/lightning.R
@@ -476,7 +476,7 @@ Lightning <- R6Class("Lightning",
          response = postForm(paste(self$serveraddress, "sessions/", sep=""),
                              .opts = list(httpheader = httpheader, postfields=jsonbody))
          response = fromJSON(response)
-         self$sessionid <- response$id
+         self$sessionid <- response["id"]
          return(response)
       },
       usesession = function(sessionid){

--- a/LightningR/R/lightning.R
+++ b/LightningR/R/lightning.R
@@ -99,7 +99,7 @@ Lightning <- R6Class("Lightning",
             browseURL(url)
          }
          if(self$notebook) {
-            return(getURL(paste(url, "embed")))
+            return(display_html(getURLContent(paste(url, "embed/", sep=""))))
          }
          return(list(url = url, id = response$id))
       },
@@ -141,6 +141,9 @@ Lightning <- R6Class("Lightning",
             browseURL(url)
          }
          self$url <- url
+         if(self$notebook) {
+            return(display_html(getURLContent(paste(url, "embed/", sep=""))))
+         }
          return(list(url = url, id = response$id))
       },
       linestacked = function(series, color = NA, label = NA, size = NA){
@@ -179,6 +182,9 @@ Lightning <- R6Class("Lightning",
          self$url <- url
          if (self$autoopen) {
             browseURL(url)
+         }
+         if(self$notebook) {
+            return(display_html(getURLContent(paste(url, "embed/", sep=""))))
          }
          return(list(url = url, id = response$id))
       },
@@ -226,6 +232,9 @@ Lightning <- R6Class("Lightning",
          if (self$autoopen) {
             browseURL(url)
          }
+         if(self$notebook) {
+            return(display_html(getURLContent(paste(url, "embed/", sep=""))))
+         }
          return(list(url = url, id = response$id))
       },
       graph = function(x, y, matrix, color = NA, label = NA, size = NA) {
@@ -267,6 +276,9 @@ Lightning <- R6Class("Lightning",
          if (self$autoopen) {
             browseURL(url)
          }
+         if(self$notebook) {
+            return(display_html(getURLContent(paste(url, "embed/", sep=""))))
+         }
          return(list(url = url, id = response$id))
       },
       map = function(regions, weights, colormap) {
@@ -282,6 +294,9 @@ Lightning <- R6Class("Lightning",
          self$url <- url
          if (self$autoopen) {
             browseURL(url)
+         }
+         if(self$notebook) {
+            return(display_html(getURLContent(paste(url, "embed/", sep=""))))
          }
          return(list(url = url, id = response$id))
       },
@@ -323,6 +338,9 @@ Lightning <- R6Class("Lightning",
          self$url <- url
          if (self$autoopen) {
             browseURL(url)
+         }
+         if(self$notebook) {
+            return(display_html(getURLContent(paste(url, "embed/", sep=""))))
          }
          return(list(url = url, id = response$id))
       },
@@ -371,6 +389,9 @@ Lightning <- R6Class("Lightning",
          if (self$autoopen) {
             browseURL(url)
          }
+         if(self$notebook) {
+            return(display_html(getURLContent(paste(url, "embed/", sep=""))))
+         }
          return(list(url = url, id = response$id))
       },
       scatterline = function(x, y, t, color = NA, label = NA, size = NA){
@@ -412,6 +433,9 @@ Lightning <- R6Class("Lightning",
          if (self$autoopen) {
             browseURL(url)
          }
+         if(self$notebook) {
+            return(display_html(getURLContent(paste(url, "embed/", sep=""))))
+         }
          return(list(url = url, id = response$id))
       },
       scatter3 = function(x, y, z, color = NA, label = NA, size = NA, alpha = NA) {
@@ -447,6 +471,9 @@ Lightning <- R6Class("Lightning",
          if (self$autoopen) {
             browseURL(url)
          }
+         if(self$notebook) {
+            return(display_html(getURLContent(paste(url, "embed/", sep=""))))
+         }
          return(list(url = url, id = response$id))
       },
       image = function(imgpath) {
@@ -457,6 +484,9 @@ Lightning <- R6Class("Lightning",
          self$url <- url
          if (self$autoopen) {
             browseURL(url)
+         }
+         if(self$notebook) {
+            return(display_html(getURLContent(paste(url, "embed/", sep=""))))
          }
          return(list(url = url, id = response$id))
       },
@@ -473,6 +503,9 @@ Lightning <- R6Class("Lightning",
          }
          if (self$autoopen) {
             browseURL(url)
+         }
+         if(self$notebook) {
+            return(display_html(getURLContent(paste(url, "embed/", sep=""))))
          }
          return(list(url = url, id = response$id))
       },

--- a/LightningR/R/lightning.R
+++ b/LightningR/R/lightning.R
@@ -45,12 +45,15 @@ Lightning <- R6Class("Lightning",
    public = list(
       serveraddress = NA,
       sessionid = NA,
+      notebook = NA,
       url = NA,
       autoopen = FALSE,
-      initialize = function(serveraddress) {
+      initialize = function(serveraddress, notebook = F) {
          if(!missing(serveraddress)){
             self$serveraddress <- serveraddress
          }
+
+         self$notebook = notebook
       },
       line = function(series, index = NA, color = NA, label = NA, size = NA, xaxis = NA, yaxis = NA, logScaleX = "false", logScaleY = "false") {
          listbuilder <- list(type = "line", opts = list(logScaleX = logScaleX, logScaleY = logScaleY))
@@ -94,6 +97,9 @@ Lightning <- R6Class("Lightning",
          self$url <- url
          if (self$autoopen) {
             browseURL(url)
+         }
+         if(self$notebook) {
+            return(getURL(paste(url, "embed")))
          }
          return(list(url = url, id = response$id))
       },

--- a/LightningR/R/lightning.R
+++ b/LightningR/R/lightning.R
@@ -56,7 +56,7 @@ Lightning <- R6Class("Lightning",
          self$notebook = notebook
       },
       line = function(series, index = NA, color = NA, label = NA, size = NA, xaxis = NA, yaxis = NA, logScaleX = "false", logScaleY = "false") {
-         listbuilder <- list(type = "line", opts = list(logScaleX = logScaleX, logScaleY = logScaleY))
+         listbuilder <- list(type = "line", options = list(logScaleX = logScaleX, logScaleY = logScaleY))
          features <- list(series = series)
 
          if (!is.na(index)) {
@@ -79,6 +79,11 @@ Lightning <- R6Class("Lightning",
          }
 
          listbuilder$data <- features
+         if(self$notebook) {
+            listbuilder$options$width = 600
+         }
+
+
 
          jsonbody <- toJSON(listbuilder, .na = "")
          oldbody = "placeholder"
@@ -90,6 +95,7 @@ Lightning <- R6Class("Lightning",
          jsonbody <- gsub(",  ]", " ]", jsonbody)
          jsonbody <- gsub('[ ,', '[', jsonbody, fixed = TRUE)
          httpheader<- c(Accept = "text/plain", "Content-Type" = "application/json")
+
          response = postForm(paste(self$serveraddress, "sessions/", self$sessionid, "/visualizations/", sep=""),
                              .opts = list(httpheader = httpheader, postfields=jsonbody))
          response = fromJSON(response)
@@ -104,7 +110,7 @@ Lightning <- R6Class("Lightning",
          return(list(url = url, id = response$id))
       },
       scatter = function(x, y, color = NA, label = NA, size = NA, alpha = NA, xaxis = NA, yaxis = NA){
-         listbuilder <- list(type = "scatter")
+         listbuilder <- list(type = "scatter", options = list())
          points <- matrix(ncol = 2, nrow = length(x))
          points[,1] <- x
          points[,2] <- y
@@ -130,7 +136,10 @@ Lightning <- R6Class("Lightning",
          }
 
          listbuilder$data <- features
-         listbuilder$opts <- c(NaN)
+         if(self$notebook) {
+            listbuilder$options$width = 600
+         }
+
          jsonbody <- toJSON(listbuilder, .na = "{}")
          httpheader<- c(Accept = "text/plain", "Content-Type" = "application/json")
          response = postForm(paste(self$serveraddress, "sessions/", self$sessionid, "/visualizations/", sep=""),
@@ -147,7 +156,7 @@ Lightning <- R6Class("Lightning",
          return(list(url = url, id = response$id))
       },
       linestacked = function(series, color = NA, label = NA, size = NA){
-         listbuilder <- list(type = "line-stacked")
+         listbuilder <- list(type = "line-stacked", options = list())
          features <- list(series = series)
 
          if (!is.na(color)) {
@@ -161,7 +170,10 @@ Lightning <- R6Class("Lightning",
          }
 
          listbuilder$data <- features
-         listbuilder$opts <- c("options")
+         if(self$notebook) {
+            listbuilder$options$width = 600
+         }
+
          jsonbody <- toJSON(listbuilder, .na = "")
 
          oldbody = "placeholder"
@@ -191,7 +203,7 @@ Lightning <- R6Class("Lightning",
       force = function(matrix, color = NA, label = NA, size = NA){
          ##matrix- connectivity matrix n by n, where value is the weight of the edge
 
-         listbuilder <- list(type = "force", opts = NA)
+         listbuilder <- list(type = "force", options = list())
          nodes <- vector(mode = "numeric", length = nrow(matrix))
          for (i in 0:(length(nodes)-1)) {
             nodes[i] <- i
@@ -221,6 +233,10 @@ Lightning <- R6Class("Lightning",
          }
 
          listbuilder$data <- features
+         if(self$notebook) {
+            listbuilder$options$width = 600
+         }
+
 
          jsonbody <- toJSON(listbuilder, .na = "{}")
          httpheader<- c(Accept = "text/plain", "Content-Type" = "application/json")
@@ -238,7 +254,7 @@ Lightning <- R6Class("Lightning",
          return(list(url = url, id = response$id))
       },
       graph = function(x, y, matrix, color = NA, label = NA, size = NA) {
-         listbuilder <- list(type = "graph", opts = NA)
+         listbuilder <- list(type = "graph", options = list())
          points <- matrix(ncol = 2, nrow = length(x))
          points[,1] <- x
          points[,2] <- y
@@ -266,6 +282,9 @@ Lightning <- R6Class("Lightning",
          }
 
          listbuilder$data <- features
+         if(self$notebook) {
+            listbuilder$options$width = 600
+         }
          jsonbody <- toJSON(listbuilder, .na = "{}")
          httpheader<- c(Accept = "text/plain", "Content-Type" = "application/json")
          response = postForm(paste(self$serveraddress, "sessions/", self$sessionid, "/visualizations/", sep=""),
@@ -282,9 +301,14 @@ Lightning <- R6Class("Lightning",
          return(list(url = url, id = response$id))
       },
       map = function(regions, weights, colormap) {
-         listbuilder <- list(type = "map", opts = NA)
+         listbuilder <- list(type = "map", options = list())
          features = list(regions = regions, values = weights, colormap = colormap)
          listbuilder$data <- features
+
+         if(self$notebook) {
+            listbuilder$options$width = 600
+         }
+
          jsonbody <- toJSON(listbuilder, .na = "{}")
          httpheader<- c(Accept = "text/plain", "Content-Type" = "application/json")
          response = postForm(paste(self$serveraddress, "sessions/", self$sessionid, "/visualizations/", sep=""),
@@ -301,7 +325,7 @@ Lightning <- R6Class("Lightning",
          return(list(url = url, id = response$id))
       },
       graphbundled = function(x, y, matrix, color = NA, label = NA, size = NA){
-         listbuilder <- list(type = "graph-bundled", opts = NA)
+         listbuilder <- list(type = "graph-bundled", options = list())
          points <- matrix(ncol = 2, nrow = length(x))
          points[,1] <- x
          points[,2] <- y
@@ -329,6 +353,11 @@ Lightning <- R6Class("Lightning",
          }
 
          listbuilder$data <- features
+
+         if(self$notebook) {
+            listbuilder$options$width = 600
+         }
+
          jsonbody <- toJSON(listbuilder, .na = "{}")
          httpheader<- c(Accept = "text/plain", "Content-Type" = "application/json")
          response = postForm(paste(self$serveraddress, "sessions/", self$sessionid, "/visualizations/", sep=""),
@@ -345,9 +374,14 @@ Lightning <- R6Class("Lightning",
          return(list(url = url, id = response$id))
       },
       matrix = function(matrix, colormap){
-         listbuilder <- list(type = "matrix", opts = NA)
+         listbuilder <- list(type = "matrix", options = list())
          features = list(matrix = matrix, colormap = colormap)
          listbuilder$data <- features
+
+         if(self$notebook) {
+            listbuilder$options$width = 600
+         }
+
          jsonbody <- toJSON(listbuilder, .na = "{}")
          httpheader<- c(Accept = "text/plain", "Content-Type" = "application/json")
          response = postForm(paste(self$serveraddress, "sessions/", self$sessionid, "/visualizations/", sep=""),
@@ -361,7 +395,7 @@ Lightning <- R6Class("Lightning",
          return(list(url = url, id = response$id))
       },
       adjacency = function (matrix, label = NA) {
-         listbuilder <- list(type = "adjacency", opts = NA)
+         listbuilder <- list(type = "adjacency", options = list())
          nodes <- c(0:(nrow(matrix) - 1))
          links <- matrix(ncol = 3, byrow = TRUE)
          for (i in 1:ncol(matrix)) {
@@ -379,6 +413,10 @@ Lightning <- R6Class("Lightning",
          }
 
          listbuilder$data <- features
+         if(self$notebook) {
+            listbuilder$options$width = 600
+         }
+
          jsonbody <- toJSON(listbuilder, .na = "{}")
          httpheader<- c(Accept = "text/plain", "Content-Type" = "application/json")
          response = postForm(paste(self$serveraddress, "sessions/", self$sessionid, "/visualizations/", sep=""),
@@ -395,7 +433,7 @@ Lightning <- R6Class("Lightning",
          return(list(url = url, id = response$id))
       },
       scatterline = function(x, y, t, color = NA, label = NA, size = NA){
-         listbuilder <- list(type = "scatter-line")
+         listbuilder <- list(type = "scatter-line", options=list())
          points <- matrix(ncol = 2, nrow = length(x))
          points[,1] <- x
          points[,2] <- y
@@ -412,7 +450,10 @@ Lightning <- R6Class("Lightning",
          }
 
          listbuilder$data <- features
-         listbuilder$opts <- c("options")
+         if(self$notebook) {
+            listbuilder$options$width = 600
+         }
+
          jsonbody <- toJSON(listbuilder, .na = "")
          oldbody = "placeholder"
 
@@ -439,7 +480,7 @@ Lightning <- R6Class("Lightning",
          return(list(url = url, id = response$id))
       },
       scatter3 = function(x, y, z, color = NA, label = NA, size = NA, alpha = NA) {
-         listbuilder <- list(type = "scatter-3")
+         listbuilder <- list(type = "scatter-3", options=list())
          points <- matrix(ncol = 3, nrow = length(x))
          points[,1] <- x
          points[,2] <- y
@@ -460,7 +501,11 @@ Lightning <- R6Class("Lightning",
          }
 
          listbuilder$data <- features
-         listbuilder$opts <- c(NaN)
+
+         if(self$notebook) {
+            listbuilder$options$width = 600
+         }
+
          jsonbody <- toJSON(listbuilder, .na = "{}")
          httpheader<- c(Accept = "text/plain", "Content-Type" = "application/json")
          response = postForm(paste(self$serveraddress, "sessions/", self$sessionid, "/visualizations/", sep=""),
@@ -477,7 +522,12 @@ Lightning <- R6Class("Lightning",
          return(list(url = url, id = response$id))
       },
       image = function(imgpath) {
-         rawresponse <- POST(url = paste(self$serveraddress, "sessions/", self$sessionid, "/visualizations/", sep=""), encode = 'multipart', body = list(file = upload_file(imgpath), type = "image"))
+         body = list(file = upload_file(imgpath), type = "image", options = list())
+         if(self$notebook) {
+            body$options$width = 600
+         }
+
+         rawresponse <- POST(url = paste(self$serveraddress, "sessions/", self$sessionid, "/visualizations/", sep=""), encode = 'multipart', body = body)
          jsonstring <- rawToChar(rawresponse$content)
          response <- fromJSON(jsonstring)
          url <- paste(self$serveraddress, "visualizations/", response$id, "/", sep="")
@@ -493,7 +543,13 @@ Lightning <- R6Class("Lightning",
       gallery = function(imgpathvector) {
          firstpath <- imgpathvector[1]
          otherpaths <- imgpathvector[-1]
-         rawresponse <- POST(url = paste(self$serveraddress, "sessions/", self$sessionid, "/visualizations/", sep=""), encode = 'multipart', body = list(file = upload_file(firstpath), type = "gallery"))
+
+         body = list(file = upload_file(firstpath), type = "gallery", options = list())
+         if(self$notebook) {
+            body$options$width = 600
+         }
+
+         rawresponse <- POST(url = paste(self$serveraddress, "sessions/", self$sessionid, "/visualizations/", sep=""), encode = 'multipart', body = body)
          jsonstring <- rawToChar(rawresponse$content)
          response <- fromJSON(jsonstring)
          url <- paste(self$serveraddress, "visualizations/", response$id, "/", sep="")


### PR DESCRIPTION
this PR includes some fixes that get the client library working with the latest version of lightning server. in particular there is a fix for ids going from integers to strings.

additionally this fixes a bug in the way that options are handles, and also allows plots to be displayed inline in the notebook, e.g with IRKernal.

re #5 I think it would be a good move to move this to the core project so that its easier to keep things up to date both in the repo and on CRAN
